### PR TITLE
Add license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 boxmodeldesign
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -3,3 +3,11 @@
 ## Links
 Notes Goog Doc:
 https://docs.google.com/document/d/15YZCScaRsNBiD7APfj74qY-Y2ALrqHozpv7AMYbosHI/edit?usp=sharing
+
+## How to work on this project
+- Download git
+- Fork this repo
+- Click "Clone or download" and copy the project URL
+- Run `~$ git clone _paste_url_`
+- Run `~$ git checkout -b _create_a_branch_name_`
+- Add your code locally, commit to changes, push up to github, submit a pull request to master branch


### PR DESCRIPTION
The instructions were added so I could get my local branch up to github so I could create the license there. The instructions don't have to stay on the README.